### PR TITLE
Bad JSON file processing

### DIFF
--- a/e2j2/helpers/parsers.py
+++ b/e2j2/helpers/parsers.py
@@ -23,7 +23,9 @@ def parse_json_file(json_file):
     except IOError:
         # Mark as failed
         return ERROR
-
+    except ValueError:
+        # Mark as failed
+        return 'Decoding JSON has failed'
     return data
 
 


### PR DESCRIPTION
Crashes if file contains badly formatted/invalid JSON which raises ValueError. 