### PR TITLE
Add --stderr option to print errors to stderr instead of to file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,12 @@ Changelog
 Fixed
 -----
 - fixed '{=' marker set
+- added --stderr flag to print errors to stderr instead of to .err file
 
 Changed
 -------
 - reworked terminal color handling
+- all output is sent to stderr instead of stdout (as it is debug output)
 
 Breaking change:
 ----------------

--- a/e2j2/constants.py
+++ b/e2j2/constants.py
@@ -36,6 +36,7 @@ CONFIG_SCHEMAS = {
             "test_first": {"type": "boolean"},
             "copy_file_permissions": {"type": "boolean"},
             "stacktrace": {"type": "boolean"},
+            "stderr": {"type": "boolean"},
             "initial_run": {"type": "boolean"},
             "marker_set": {"type": "string", "enum": ["{{", "{=", "<=", "[=", "(="]},
             "autodetect_marker_set": {"type": "boolean"},

--- a/e2j2/display.py
+++ b/e2j2/display.py
@@ -48,10 +48,10 @@ def write(msg):
     counter = cache.log_repeat_log_msg_counter
 
     if cache.last_log_line != msg:
-        sys.stdout.write(msg)
+        sys.stderr.write(msg)
         cache.log_repeat_log_msg_counter = 0
     elif counter == print_at:
-        sys.stdout.write('({}x) '.format(print_at) + msg)
+        sys.stderr.write('({}x) '.format(print_at) + msg)
         cache.print_at += increment
         cache.log_repeat_log_msg_counter = 0
 


### PR DESCRIPTION
This would seriously simplify debugging in the build pipeline for containers that are auto-removed by not having to manually cat .err files and all